### PR TITLE
Explicitly specify path to type definitions in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
       "default": "./lib/import-single.cjs"
     }
   },
+  "types": "./lib/import-single.d.ts",
   "files": [
     "lib"
   ],


### PR DESCRIPTION
Hello! I noticed when trying to use your package from a TypeScript project that the `tsc` generated type definition file isn't being picked up. The NPM webpage also does not indicate that type definitions are available.

I dug into your build setup and noticed that you are outputting definition files, but not explicitly referencing them from the `types` property in `package.json`. They're referenced under `exports`, but I'm honestly not too sure what the support for that property is like within the TypeScript ecosystem. It looks like it only works when `moduleResolution` is set as `node16` or `nodenext`, but that isn't compatible with `module: commonjs`.

Just for additional context if necessary, I'm using TypeScript 5.7.3 with Node 22.

By the way, great package—thank you :>